### PR TITLE
Add Wikipedia references and update README for Acura TSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Acura TSX
 
+This repository contains signal set configurations for the Acura TSX, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Acura TSX.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Acura_TSX"
+
 generations:
   - name: "First Generation"
     start_year: 2004


### PR DESCRIPTION
- Added: Wikipedia reference to generations.yaml
- Updated: README.md with standard template
- Verified: Both generation years correct per Wikipedia (2004-2008, 2009-2014)

Per Wikipedia: First generation 2004-2008, second generation 2009-2014. All model years in the current YAML are accurate.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
